### PR TITLE
Encode file_id as UTF-8 before hashing.

### DIFF
--- a/squiffy.py
+++ b/squiffy.py
@@ -303,7 +303,7 @@ class Story:
 
     def set_id(self, filename):
         file_id = str(uuid.getnode()) + filename
-        self.id = hashlib.sha1(file_id).hexdigest()[0:10]
+        self.id = hashlib.sha1(file_id.encode('utf-8')).hexdigest()[0:10]
 
 class Section:
     def __init__(self, name, filename, line):


### PR DESCRIPTION
On Python 3.3.5 I get the following output when trying to compile anything with squiffy:

``` python
> squiffy.py example.squiffy
Traceback (most recent call last):
  File "squiffy.py", line 355, in <module>
    process(sys.argv[1], os.path.abspath(os.path.dirname(sys.argv[0])))
  File "squiffy.py", line 15, in process
    story.set_id(os.path.abspath(input_filename))
  File "squiffy.py", line 306, in set_id
    self.id = hashlib.sha1(file_id).hexdigest()[0:10]
TypeError: Unicode-objects must be encoded before hashing
```

Encoding the file_id as utf-8 before hashing fixes it.
