### PR TITLE
fix issue #40

### DIFF
--- a/squiffy.template.js
+++ b/squiffy.template.js
@@ -136,7 +136,7 @@ var squiffy = {};
         if (stripParagsMatch) {
             text = stripParagsMatch[1];
         }
-        var $labels = $('.squiffy-label-' + label);
+        var $labels = currentSection.find('.squiffy-label-' + label);
         $labels.fadeOut(1000, function() {
             $labels.html(squiffy.ui.processText(text));
             $labels.fadeIn(1000, function() {

--- a/squiffy.template.js
+++ b/squiffy.template.js
@@ -136,7 +136,7 @@ var squiffy = {};
         if (stripParagsMatch) {
             text = stripParagsMatch[1];
         }
-        var $labels = currentSection.find('.squiffy-label-' + label);
+        var $labels = $('.squiffy-label-' + label);
         $labels.fadeOut(1000, function() {
             $labels.html(squiffy.ui.processText(text));
             $labels.fadeIn(1000, function() {


### PR DESCRIPTION
the replacement wouldn't apply to all of them with the proviso that no
same label in one section
eg:
{label:1=a pint of milk}.
{label:1=bought a pint of milk}.

that will not work, until we change it to

{label:1=a pint of milk}.
{label:2=bought a pint of milk}.