### PR TITLE
Solved first part of bug #68

### DIFF
--- a/squiffy.template.js
+++ b/squiffy.template.js
@@ -421,7 +421,7 @@ var squiffy = {};
 
             var text = command.substring(colon + 1);
             var condition = command.substring(0, colon);
-
+			condition = condition.replace("<", "&lt;");
             var operatorRegex = /([\w ]*)(=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;)(.*)/;
             var match = operatorRegex.exec(condition);
 


### PR DESCRIPTION
The marked module of mpn has a bug that not replace de < symbol. Insert one line before the comparation of condition to replace this.