### PR TITLE
Update packages because of security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "5.1.2",
   "description": "A tool for creating multiple-choice interactive stories",
   "dependencies": {
-    "finalhandler": "^0.3.1",
-    "glob": "^4.0.6",
-    "jquery": "^2.1.3",
+    "finalhandler": "^1.1.1",
+    "glob": "^7.1.2",
+    "jquery": "^3.3.1",
     "jszip": "^2.4.0",
     "marked": "^0.3.2",
     "serve-static": "^1.7.0",


### PR DESCRIPTION
This fixes the following security issues:

* https://nodesecurity.io/advisories?search=debug&version=2.2.0 
* https://nodesecurity.io/advisories?search=jquery&version=2.2.4
* https://nodesecurity.io/advisories?search=minimatch&version=2.0.10

For this sort of application, not a big issue, but there's no reason not to keep the packages up-to-date. This clears the warnings when installing via `npm`.

As for breakage, all the scripts in the examples directory seem to compile fine. The change from jquery 2.x to 3.x could perhaps break user scripts though: https://jquery.com/upgrade-guide/3.0/