### PR TITLE
Fix autoSectionCount when used with import

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -19,7 +19,9 @@
     var glob = require('glob');
     var marked = require('marked');
     var crypto = require('crypto');
-
+    
+    var autoSectionCount = 0;
+	
     var packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json')).toString());
     var squiffyVersion = packageJson.version;
 
@@ -260,7 +262,6 @@
 
             var compiler = this;
             var lineCount = 0;
-            var autoSectionCount = 0;
             var section = null;
             var passage = null;
             var textStarted = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squiffy",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "A tool for creating multiple-choice interactive stories",
   "dependencies": {
     "finalhandler": "^0.3.1",


### PR DESCRIPTION
Move declaration of var autoSectionCount  out of processFileText function as its called on each file during import, causing continues to reuse the same numbers.

to resolve #82  