### PR TITLE
Export using global version of runtime

### DIFF
--- a/cli/src/file-packager.ts
+++ b/cli/src/file-packager.ts
@@ -11,7 +11,8 @@ async function getCompileResult(inputFilename: string) {
         scriptBaseFilename: path.basename(inputFilename),
         script: inputText,
         onWarning: console.warn,
-        externalFiles: externalFiles(inputFilename)
+        externalFiles: externalFiles(inputFilename),
+        globalJs: true,
     });
 }
 

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -34,6 +34,7 @@ interface CompilerSettings {
     script: string;
     onWarning?: (message: string) => void;
     externalFiles?: ExternalFiles;
+    globalJs?: boolean;
 }
 
 interface ExternalFiles {
@@ -71,7 +72,12 @@ export async function compile(settings: CompilerSettings): Promise<CompileSucces
             outputJs.push(`// Created with Squiffy ${version}`);
             outputJs.push('// https://github.com/textadventures/squiffy');
         }
-        outputJs.push('export const story = {};');
+        if (settings.globalJs) {
+            outputJs.push('var story = {};');
+        }
+        else {
+            outputJs.push('export const story = {};');
+        }
         outputJs.push(`story.id = ${JSON.stringify(storyData.story.id, null, 4)};`);
         if (storyData.story.uiJsIndex !== undefined) {
             outputJs.push(`story.uiJsIndex = ${storyData.story.uiJsIndex};`);

--- a/editor/src/main.ts
+++ b/editor/src/main.ts
@@ -98,7 +98,7 @@ const downloadSquiffyScript = function () {
 
 const downloadZip = async function () {
     localSave();
-    const result = await compile();
+    const result = await compile(true);
 
     if (result.success) {
         const pkg = await createPackage(result, true);
@@ -111,7 +111,7 @@ const downloadZip = async function () {
 
 const downloadJavascript = async function () {
     localSave();
-    const result = await compile();
+    const result = await compile(true);
 
     if (result.success) {
         const js = await result.getJs();
@@ -213,7 +213,7 @@ const editorChange = async function () {
     clearDebugger();
     
     if (squiffyApi) {
-        const result = await compile();
+        const result = await compile(false);
 
         if (result.success) {
             const story = getStoryFromCompilerOutput(result.output);
@@ -520,7 +520,7 @@ const logToDebugger = function (text: string) {
     debuggerEl.scrollTop = debuggerEl.scrollHeight;
 };
 
-const compile = async function() {
+const compile = async function(forExportPackage: boolean) {
     const script = editor.getValue();
     const warnings: string[] = [];
 
@@ -529,7 +529,8 @@ const compile = async function() {
         script: script,
         onWarning: (message: string) => {
             warnings.push(message);
-        }
+        },
+        globalJs: forExportPackage,
     });
 
     if (!result.success) {
@@ -542,7 +543,7 @@ const compile = async function() {
 };
 
 const initialCompile = async function () {
-    const result = await compile();
+    const result = await compile(false);
 
     if (!result.success) {
         return;

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,4 +1,5 @@
 index.html
 squiffy.runtime.js
+squiffy.runtime.global.js
 story.js
 style.css

--- a/packager/src/index.template.html
+++ b/packager/src/index.template.html
@@ -6,12 +6,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- SCRIPTS -->
-    <script type="module">
-        import {init} from './squiffy.runtime.js';
-        import {story} from './story.js';
-
+    <script src="squiffy.runtime.global.js"></script>
+    <script src="story.js"></script>
+    <script>
         document.addEventListener('DOMContentLoaded', async function () {
-            const squiffyApi = await init({
+            const squiffyApi = await squiffyRuntime.init({
                 element: document.getElementById('squiffy'),
                 story: story,
                 persist: true,

--- a/packager/src/packager.ts
+++ b/packager/src/packager.ts
@@ -1,7 +1,7 @@
 import {strToU8, zipSync} from "fflate";
 import {CompileSuccess} from 'squiffy-compiler';
 
-import squiffyRuntime from 'squiffy-runtime/dist/squiffy.runtime.js?raw';
+import squiffyRuntime from 'squiffy-runtime/dist/squiffy.runtime.global.js?raw';
 import htmlTemplateFile from './index.template.html?raw';
 import cssTemplateFile from './style.template.css?raw';
 
@@ -18,12 +18,12 @@ export const createPackage = async (input: CompileSuccess, createZip: boolean): 
     const output: Record<string, string> = {};
 
     output['story.js'] = await input.getJs();
-    output['squiffy.runtime.js'] = squiffyRuntime;
+    output['squiffy.runtime.global.js'] = squiffyRuntime;
 
     const uiInfo = input.getUiInfo();
 
     let htmlData = htmlTemplateFile.toString();
-    htmlData = htmlData.replace('<!-- INFO -->', `<!--\n\nCreated with Squiffy ${version}\n\n\nhttps://github.com/textadventures/squiffy\n\n-->`);
+    htmlData = htmlData.replace('<!-- INFO -->', `<!--\n\nCreated with Squiffy ${version}\n\nhttps://squiffystory.com\nhttps://github.com/textadventures/squiffy\n\n-->`);
     htmlData = htmlData.replace('<!-- TITLE -->', uiInfo.title);
     const scriptData = uiInfo.externalScripts.map(script => `<script src="${script}"></script>`).join('\n');
     htmlData = htmlData.replace('<!-- SCRIPTS -->', scriptData);

--- a/runtime/vite.config.ts
+++ b/runtime/vite.config.ts
@@ -6,16 +6,31 @@ export default defineConfig({
         target: "es2020",
         sourcemap: true,
         minify: "esbuild",
+
         lib: {
             entry: "src/squiffy.runtime.ts",
-            formats: ["es"],
-            fileName: 'squiffy.runtime'
+            name: "squiffyRuntime"
+        },
+
+        rollupOptions: {
+            output: [
+                {
+                    format: "es",
+                    entryFileNames: "squiffy.runtime.js"
+                },
+                {
+                    format: "iife",
+                    name: "squiffyRuntime",
+                    entryFileNames: "squiffy.runtime.global.js"
+                }
+            ]
         }
     },
+
     plugins: [
         dts({
             entryRoot: "src",
-            outDir: "dist",
+            outDir: "dist"
         })
-    ],
+    ]
 });


### PR DESCRIPTION
Adds a new Squiffy Runtime build config, to generate a version that adds the runtime to a global `squiffyRuntime` object. We use this version in the Packager, so we now generate HTML & JS that does _not_ use modules. This means these files can be run from the local file system (which doesn't work when using `import`).