### PR TITLE
Deduplicate CSS

### DIFF
--- a/editor/public/preview.css
+++ b/editor/public/preview.css
@@ -1,30 +1,7 @@
-a.squiffy-link
-{
-    text-decoration: underline;
-    text-decoration-color: Blue;
-    color: Blue;
-    cursor: pointer;
-    transition: color 0.4s ease-in-out, text-decoration-color 0.4s ease-in-out;
-}
-a.squiffy-link.disabled,
-div.squiffy-output-section:not(:last-child) a.squiffy-link,
-div.squiffy-output-section.links-disabled a.squiffy-link
-{
-    text-decoration: inherit;
-    text-decoration-color: transparent;
-    color: inherit !important;
-    cursor: inherit;
-    pointer-events: none;
-}
-button.squiffy-header-button
-{
-    text-decoration: underline;
-    color: Blue;
-    cursor: pointer;
-    background: none;
-    border: none;
-    font-family: inherit;
-}
+/* Note: Core squiffy runtime styles are loaded from squiffy.runtime.css in the runtime package */
+/* This file is for the preview pane in the editor and uses the packager's style template */
+
+/* Application-specific layout and container styles */
 div#squiffy-container
 {
     max-width: 700px;
@@ -40,19 +17,4 @@ div#squiffy-header
 div#squiffy
 {
     font-size: 18px;
-}
-div.squiffy-output-block:not(:last-child),
-div.squiffy-output-passage:not(:last-child),
-div.squiffy-output-section:not(:last-child)
-{
-    margin-bottom: 1em;
-    border-bottom: 1px solid #ccc;
-}
-.fade-out {
-    opacity: 0;
-    transition: opacity 200ms;
-}
-.fade-in {
-    opacity: 1;
-    transition: opacity 200ms;
 }

--- a/editor/src/editor.css
+++ b/editor/src/editor.css
@@ -1,34 +1,8 @@
+@import 'squiffy-runtime/squiffy.runtime.css';
+
 html, body {
     height: 100%;
     overflow: hidden;
-}
-
-a.squiffy-link
-{
-    text-decoration: underline;
-    text-decoration-color: Blue;
-    color: Blue;
-    cursor: pointer;
-    transition: color 0.4s ease-in-out, text-decoration-color 0.4s ease-in-out;
-}
-
-a.squiffy-link.disabled,
-div.squiffy-output-section:not(:last-child) a.squiffy-link,
-div.squiffy-output-section.links-disabled a.squiffy-link
-{
-    text-decoration: inherit;
-    text-decoration-color: transparent;
-    color: inherit !important;
-    cursor: inherit;
-    pointer-events: none;
-}
-
-div.squiffy-output-block:not(:last-child),
-div.squiffy-output-passage:not(:last-child),
-div.squiffy-output-section:not(:last-child)
-{
-    margin-bottom: 1em;
-    border-bottom: 1px solid #ccc;
 }
 
 #editor {

--- a/editor/src/preview.ts
+++ b/editor/src/preview.ts
@@ -1,6 +1,7 @@
 import { init as runtimeInit } from "squiffy-runtime";
 import { compile as squiffyCompile } from "squiffy-compiler";
 import { getStoryFromCompilerOutput } from "./compiler-helper.ts";
+import "squiffy-runtime/squiffy.runtime.css";
 
 document.addEventListener("DOMContentLoaded", async () => {
     if (!window.opener) {

--- a/packager/src/packager.ts
+++ b/packager/src/packager.ts
@@ -2,6 +2,7 @@ import { strToU8, zipSync } from "fflate";
 import { CompileSuccess } from "squiffy-compiler";
 
 import squiffyRuntime from "squiffy-runtime/dist/squiffy.runtime.global.js?raw";
+import runtimeCss from "squiffy-runtime/dist/squiffy.runtime.css?raw";
 import htmlTemplateFile from "./index.template.html?raw";
 import cssTemplateFile from "./style.template.css?raw";
 
@@ -32,7 +33,8 @@ export const createPackage = async (input: CompileSuccess, createZip: boolean): 
     htmlData = htmlData.replace("<!-- STYLESHEETS -->", stylesheetData);
 
     output["index.html"] = htmlData;
-    output["style.css"] = cssTemplateFile.toString();
+    // Combine runtime CSS with application-specific container styles
+    output["style.css"] = runtimeCss.toString() + "\n\n" + cssTemplateFile.toString();
 
     return {
         files: output,

--- a/packager/src/style.template.css
+++ b/packager/src/style.template.css
@@ -1,30 +1,4 @@
-a.squiffy-link
-{
-    text-decoration: underline;
-    text-decoration-color: Blue;
-    color: Blue;
-    cursor: pointer;
-    transition: color 0.4s ease-in-out, text-decoration-color 0.4s ease-in-out;
-}
-a.squiffy-link.disabled,
-div.squiffy-output-section:not(:last-child) a.squiffy-link,
-div.squiffy-output-section.links-disabled a.squiffy-link
-{
-    text-decoration: inherit;
-    text-decoration-color: transparent;
-    color: inherit !important;
-    cursor: inherit;
-    pointer-events: none;
-}
-button.squiffy-header-button
-{
-    text-decoration: underline;
-    color: Blue;
-    cursor: pointer;
-    background: none;
-    border: none;
-    font-family: inherit;
-}
+/* Application-specific layout and container styles */
 div#squiffy-container
 {
     max-width: 700px;
@@ -40,19 +14,4 @@ div#squiffy-header
 div#squiffy
 {
     font-size: 18px;
-}
-div.squiffy-output-block:not(:last-child),
-div.squiffy-output-passage:not(:last-child),
-div.squiffy-output-section:not(:last-child)
-{
-    margin-bottom: 1em;
-    border-bottom: 1px solid #ccc;
-}
-.fade-out {
-    opacity: 0;
-    transition: opacity 200ms;
-}
-.fade-in {
-    opacity: 1;
-    transition: opacity 200ms;
 }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -4,6 +4,19 @@
   "type": "module",
   "main": "dist/squiffy.runtime.js",
   "types": "dist/squiffy.runtime.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/squiffy.runtime.d.ts",
+      "default": "./dist/squiffy.runtime.js"
+    },
+    "./squiffy.runtime.css": "./dist/squiffy.runtime.css",
+    "./dist/squiffy.runtime.global.js": "./dist/squiffy.runtime.global.js",
+    "./dist/squiffy.runtime.css": "./dist/squiffy.runtime.css",
+    "./dist/events": {
+      "types": "./dist/events.d.ts",
+      "default": "./dist/events.js"
+    }
+  },
   "scripts": {
     "dev": "vitest",
     "test": "vitest --run",

--- a/runtime/src/squiffy.runtime.css
+++ b/runtime/src/squiffy.runtime.css
@@ -1,0 +1,54 @@
+/* Core Squiffy Runtime Styles */
+
+/* Link styles */
+a.squiffy-link
+{
+    text-decoration: underline;
+    text-decoration-color: Blue;
+    color: Blue;
+    cursor: pointer;
+    transition: color 0.4s ease-in-out, text-decoration-color 0.4s ease-in-out;
+}
+
+/* Disabled link states */
+a.squiffy-link.disabled,
+div.squiffy-output-section:not(:last-child) a.squiffy-link,
+div.squiffy-output-section.links-disabled a.squiffy-link
+{
+    text-decoration: inherit;
+    text-decoration-color: transparent;
+    color: inherit !important;
+    cursor: inherit;
+    pointer-events: none;
+}
+
+/* Header button styles */
+button.squiffy-header-button
+{
+    text-decoration: underline;
+    color: Blue;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-family: inherit;
+}
+
+/* Output block spacing */
+div.squiffy-output-block:not(:last-child),
+div.squiffy-output-passage:not(:last-child),
+div.squiffy-output-section:not(:last-child)
+{
+    margin-bottom: 1em;
+    border-bottom: 1px solid #ccc;
+}
+
+/* Fade animations */
+.fade-out {
+    opacity: 0;
+    transition: opacity 200ms;
+}
+
+.fade-in {
+    opacity: 1;
+    transition: opacity 200ms;
+}

--- a/runtime/vite.config.ts
+++ b/runtime/vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { copyFileSync, mkdirSync } from "fs";
+import { resolve } from "path";
 
 export default defineConfig({
     build: {
@@ -31,6 +33,20 @@ export default defineConfig({
         dts({
             entryRoot: "src",
             outDir: "dist"
-        })
+        }),
+        {
+            name: "copy-css",
+            closeBundle() {
+                try {
+                    mkdirSync("dist", { recursive: true });
+                    copyFileSync(
+                        resolve("src/squiffy.runtime.css"),
+                        resolve("dist/squiffy.runtime.css")
+                    );
+                } catch (err) {
+                    console.error("Failed to copy CSS file:", err);
+                }
+            }
+        }
     ]
 });

--- a/site/src/components/Sample.astro
+++ b/site/src/components/Sample.astro
@@ -5,6 +5,7 @@ interface Props {
 }
 
 import Split from "./Split.astro";
+import "squiffy-runtime/squiffy.runtime.css";
 
 const { script, alwaysShowRestart } = Astro.props;
 
@@ -12,38 +13,11 @@ const restartClass = "sample-button restart" + (!alwaysShowRestart ? " hidden" :
 ---
 
 <style is:global>
+    /* Override runtime CSS link colors with theme colors */
     a.squiffy-link
     {
-        text-decoration: underline;
         text-decoration-color: var(--sl-color-text-accent);
         color: var(--sl-color-text-accent);
-        cursor: pointer;
-        transition: color 0.4s ease-in-out, text-decoration-color 0.4s ease-in-out;
-    }
-    a.squiffy-link.disabled,
-    div.squiffy-output-section:not(:last-child) a.squiffy-link,
-    div.squiffy-output-section.links-disabled a.squiffy-link
-    {
-        text-decoration: inherit;
-        text-decoration-color: transparent;
-        color: inherit !important;
-        cursor: inherit;
-        pointer-events: none;
-    }
-    div.squiffy-output-block:not(:last-child),
-    div.squiffy-output-passage:not(:last-child),
-    div.squiffy-output-section:not(:last-child)
-    {
-        margin-bottom: 1em;
-        border-bottom: 1px solid #ccc;
-    }
-    .fade-out {
-        opacity: 0;
-        transition: opacity 200ms;
-    }
-    .fade-in {
-        opacity: 1;
-        transition: opacity 200ms;
     }
     .viewer-container {
         padding: 0.5em;


### PR DESCRIPTION
Fixes #130

Core Squiffy styles (.squiffy-link, .squiffy-output-block, etc.) were duplicated across 4 files. They are now defined once in runtime/src/squiffy.runtime.css and imported by packager, editor, and site, reducing duplication and making the runtime package the single source of truth for core UI styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)