### PR TITLE
Fix link colours in Squiffy site samples

### DIFF
--- a/site/src/components/Sample.astro
+++ b/site/src/components/Sample.astro
@@ -16,8 +16,8 @@ const restartClass = "sample-button restart" + (!alwaysShowRestart ? " hidden" :
     /* Override runtime CSS link colors with theme colors */
     a.squiffy-link
     {
-        text-decoration-color: var(--sl-color-text-accent);
-        color: var(--sl-color-text-accent);
+        text-decoration-color: var(--sl-color-text-accent) !important;
+        color: var(--sl-color-text-accent) !important;
     }
     .viewer-container {
         padding: 0.5em;


### PR DESCRIPTION
via Claude:

After the CSS deduplication in commit b93c285, the Squiffy link colors in the site samples were showing as blue instead of the theme accent color. This happened because the runtime CSS was being loaded after the Sample component's override CSS, causing the blue color to take precedence.

Fixed by adding !important to the color and text-decoration-color properties in the Sample.astro override, ensuring the theme colors always take precedence over the runtime defaults.