### PR TITLE
Fix "{{live}}" sample on site

### DIFF
--- a/runtime/src/plugins/live.ts
+++ b/runtime/src/plugins/live.ts
@@ -53,9 +53,8 @@ export function LivePlugin(): SquiffyPlugin {
                 await Promise.all(promises);
             };
 
-            let setQueue: Promise<void> = Promise.resolve();
-            squiffy.on("set", (e) => {
-                setQueue = setQueue.then(() => onSet(e));
+            squiffy.on("set", async (e) => {
+                await onSet(e);
             });
         },
         onWrite(element: HTMLElement) {


### PR DESCRIPTION
This reverts an attempt to queue updates to `{{live}}` elements. It wasn't working correctly on the documentation site - something to do with the Promise not returning, probably if the element is hidden at the time causing the `fade-out` to never resolve?