### PR TITLE
Section clear before creating new one

### DIFF
--- a/runtime/src/squiffy.runtime.ts
+++ b/runtime/src/squiffy.runtime.ts
@@ -159,7 +159,6 @@ export const init = async (options: SquiffyInitOptions): Promise<SquiffyApi> => 
 
     async function go(sectionName: string) {
         const oldCanGoBack = canGoBack();
-        newSection(sectionName);
         currentSection = story.sections[sectionName];
         if (!currentSection) return;
         set("_section", sectionName);
@@ -168,6 +167,7 @@ export const init = async (options: SquiffyInitOptions): Promise<SquiffyApi> => 
         if (master?.clear || currentSection.clear) {
             clearScreen();
         }
+        newSection(sectionName);
         if (master) {
             await run(master, "[[]]");
         }


### PR DESCRIPTION
Fixes a bug where using `@clear` in a section would just leave you on a blank screen. We need to clear the screen first, _then_ create the div for the new section, so the output goes there. Otherwise the output keeps on going to the old section div which is now in the clear-stack.