### PR TITLE
Export JS as story.js

### DIFF
--- a/editor/src/main.ts
+++ b/editor/src/main.ts
@@ -97,7 +97,7 @@ const downloadJavascript = async function () {
 
     if (result.success) {
         const js = await result.getJs();
-        downloadString(js, title + ".js");
+        downloadString(js, "story.js");
     }
 };
 


### PR DESCRIPTION
Changed the JavaScript export filename from using the story title (title + ".js") to the standard "story.js" to match the CLI and packager behavior. This eliminates the need for users to rename the exported file before use.

Fixes #157