### PR TITLE
Fix syntax highlighting bugs in Squiffy editor (#170)

### DIFF
--- a/editor/src/ace-integration.js
+++ b/editor/src/ace-integration.js
@@ -81,7 +81,7 @@ export const init = () => {
                     },
                     {
                         token: "string",
-                        regex: /\{\{(.*)\}\}/
+                        regex: /\{\{.*?\}\}/
                     },
                     {
                         token: "support.other",
@@ -96,6 +96,10 @@ export const init = () => {
             };
 
             this.embedRules(JsHighlightRules, "js-", [{
+                token: "empty",
+                regex: /^(?!\t| {4})/,
+                next: "start"
+            }, {
                 token: "keyword",
                 regex: "$",
                 next: "start"


### PR DESCRIPTION
Fix two Ace editor highlighting issues:

1. @ commands after JavaScript blocks: Add a negative lookahead rule
   to the JS embed exit rules that transitions back to the start state
   when a line doesn't begin with indentation (tab or 4 spaces). This
   ensures @ commands following JS blocks get proper highlighting.

2. Multiple Handlebars expressions on one line: Change the Handlebars
   regex from greedy (.*) to non-greedy (.*?) so that each {{...}}
   expression is matched individually instead of matching everything
   between the first {{ and last }}.

https://claude.ai/code/session_01G218M1zXP9dDvVQ2U8n37d