### PR TITLE
Prevent Dependabot from proposing TypeScript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- `typescript-eslint`'s peer dependency range (`<6.1.0`) doesn't support TypeScript 7 yet, so a bump to 7.x breaks `npm ci` for the whole grouped Dependabot update (see #231, closed).
- Adds an `ignore` rule for major version bumps of `typescript` in `.github/dependabot.yml` until the ecosystem (typescript-eslint, Astro/@volar) catches up.

## Test plan
- [x] Reviewed `.github/dependabot.yml` diff — only adds an `ignore` block, no other changes
- [ ] Confirm Dependabot stops proposing `typescript` 7.x bumps on next scheduled run