### PR TITLE
Split dependabot groups by update-type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      dependencies-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- A grouped dependabot PR reports the highest-severity update-type across every package in it, so a single major bump bundled into the group blocks auto-merge for all the minor/patch updates alongside it — this is what happened with PR #250 (lerna 9.0.7 -> 10.0.1 blocked auto-merge for 17 other minor/patch updates).
- Splits the `dependencies` group into a minor/patch group (stays auto-mergeable) and a separate `dependencies-major` group (opens its own PR for manual review, doesn't block the rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)